### PR TITLE
Drop Debian Buster due to EOL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        debian: ["buster", "bullseye", "bookworm"]
+        debian: ["bullseye", "bookworm"]
         debian-arch: ["amd64"]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ sudo apt update
 sudo apt install vaultwarden
 ```
 
-For Debian 10 (buster):
-```bash
-wget -qO- https://vaultwarden-deb.pages.dev/dists/buster/install.sh | sudo bash
-sudo apt update
-sudo apt install vaultwarden
-```
-
 The packages can also be downloaded manually from the [repository web page](https://vaultwarden-deb.pages.dev/).
 
 ## Important configuration

--- a/build-pages-html.py
+++ b/build-pages-html.py
@@ -11,7 +11,6 @@ from distutils.version import LooseVersion
 DEBIAN_RELEASES = {
     "bookworm": { "version": 12 },
     "bullseye": { "version": 11 },
-    "buster": { "version": 10 },
 }
 ARCHITECTURES = [ "amd64" ]
 

--- a/build-pages.sh
+++ b/build-pages.sh
@@ -5,7 +5,7 @@ set -e
 mkdir -p repo
 ./sync-s3.sh s3://${AWS_S3_BUCKET}/ repo/
 
-for release in buster bullseye bookworm ; do
+for release in bullseye bookworm ; do
   cp install.sh repo/dists/$release/install.sh
   sed -i 's/DEBIAN_TARGET_VERSION=[a-z]+/DEBIAN_TARGET_VERSION='$release'/' repo/dists/$release/install.sh
   sed -i 's/BASEURL=.\+/BASEURL=https:\/\/vaultwarden-deb.pages.dev/' repo/dists/$release/install.sh

--- a/vaultwarden/build-in-docker.sh
+++ b/vaultwarden/build-in-docker.sh
@@ -3,11 +3,7 @@ set -e
 set -x
 
 SOURCE_URL=https://github.com/dani-garcia/vaultwarden/archive/refs/tags/${VW_SERVER_VERSION}.tar.gz
-if [[ $DEBIAN_TARGET_VERSION == buster ]] ; then
-  RUST_IMAGE=rust:1.79-${DEBIAN_TARGET_VERSION}
-else
-  RUST_IMAGE=rust:1.80-${DEBIAN_TARGET_VERSION}
-fi
+RUST_IMAGE=rust:1.80-${DEBIAN_TARGET_VERSION}
 
 # download latest source
 wget -O vaultwarden.tar.gz $SOURCE_URL


### PR DESCRIPTION
Some weeks ago Debian Buster repositories are moved to archive. Let's also drop buster builds for Vaultwarden.